### PR TITLE
Fix pnpm install metadata fetch error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
-    "installCommand": "pnpm install --no-frozen-lockfile",
-    "buildCommand": "pnpm run build"
-    }
+    "installCommand": "npm install",
+    "buildCommand": "npm run build"
+}


### PR DESCRIPTION
Switch Vercel build commands from pnpm to npm to resolve `ERR_INVALID_THIS` errors with Node.js 22.x.

The `pnpm install` command was failing on Vercel with Node.js 22.x, showing `ERR_INVALID_THIS` errors during package fetching. Since the `package.json` already indicated `npm` as the preferred package manager, updating `vercel.json` to use `npm install` and `npm run build` resolves the compatibility issue and ensures consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc476e14-73cf-49fc-be2a-cdca449d033d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dc476e14-73cf-49fc-be2a-cdca449d033d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>